### PR TITLE
feat: add /Unattend flag for fully automated, non-interactive installs

### DIFF
--- a/AIOInstaller.bat
+++ b/AIOInstaller.bat
@@ -24,6 +24,12 @@ setlocal & pushd .
 cd /d %~dp0
 if '%1'=='ELEV' (del "%vbsGetPrivileges%" 1>nul 2>nul  &  shift /1)
 
+REM Parse /Unattend or -Unattend flag (forwarded through UAC elevation)
+set "PCGR_UNATTEND="
+:parseArgs
+if /i "%~1"=="/Unattend" (set "PCGR_UNATTEND=1" & shift & goto :parseArgs)
+if /i "%~1"=="-Unattend" (set "PCGR_UNATTEND=1" & shift & goto :parseArgs)
+
 cls
 title PC Gaming Redists AIO Installer
 color 07
@@ -82,6 +88,14 @@ set /a "OPT_SILENT=1"
 set /a "OPT_FORCE=0"
 set "OPT_LOGFILE=log.txt"
 set /a "MENU_POS=0"
+REM Base directory for log file (overridden to %TEMP%\ when /Unattend)
+set "PCGR_LOGDIR=%~dp0"
+REM Unattended mode: enable logging to %TEMP% and skip all interactive prompts
+if defined PCGR_UNATTEND (
+    set /a "OPT_LOG=1"
+    set "OPT_LOGFILE=pcgr_aio_%COMPUTERNAME%.log"
+    set "PCGR_LOGDIR=%TEMP%\"
+)
 REM OPT_EXTRAS: 0=Enabled, 1=No 7Zip, 2=Disabled
 REM OPT_OUTPUT/OPT_LOG: 0=DISABLED, 1=All Output, 2=All Errors
 REM OPT_FORCE: 0=DISABLED, 1=VC++, 2=.NET, 3=ASP.NET, 4=Extras, 5=ALL
@@ -108,6 +122,7 @@ set "FORCEVAL[3]=Extras"
 set "FORCEVAL[4]=ALL"
 
 :splash
+if defined PCGR_UNATTEND goto :startInstall
 cls
 echo.
 call :rainbowsep
@@ -161,6 +176,7 @@ goto :splash
 :startInstall
 cls
 title PCGR - PC Gaming Redists - Installing...
+set /a "WINGET_RETRY_COUNT=0"
 
 REM Disable QuickEdit unless user enabled "Allow click to pause"
 if !OPT_CLICKPAUSE!==0 (
@@ -168,9 +184,9 @@ if !OPT_CLICKPAUSE!==0 (
 )
 
 REM If log file exists and is over 5MB, clear it
-if exist "%~dp0!OPT_LOGFILE!" (
-    for %%F in ("%~dp0!OPT_LOGFILE!") do (
-        if %%~zF GTR 5242880 del "%~dp0!OPT_LOGFILE!"
+if exist "!PCGR_LOGDIR!!OPT_LOGFILE!" (
+    for %%F in ("!PCGR_LOGDIR!!OPT_LOGFILE!") do (
+        if %%~zF GTR 5242880 del "!PCGR_LOGDIR!!OPT_LOGFILE!"
     )
 )
 
@@ -203,6 +219,16 @@ if %errorlevel% NEQ 0 (
     echo.
     echo ============================================
     echo.
+    if defined PCGR_UNATTEND (
+        set /a "WINGET_RETRY_COUNT+=1"
+        if !WINGET_RETRY_COUNT! GTR 5 (
+            call :rainbow "WinGet still not working after 5 retries - cannot continue."
+            exit /b 1
+        )
+        call :rainbow "WinGet not ready - retrying [!WINGET_RETRY_COUNT!/5] in 10s..."
+        timeout /t 10 /nobreak >nul
+        goto :checkWinget
+    )
     choice /C YN /M "Retry WinGet check"
     if errorlevel 2 goto :wingetFailed
     if errorlevel 1 goto :checkWinget
@@ -213,8 +239,8 @@ goto :wingetOK
 :wingetFailed
 echo.
 echo Cannot continue without working WinGet. Exiting...
-pause
-exit /B
+if not defined PCGR_UNATTEND pause
+exit /B 1
 
 :wingetOK
 cls
@@ -372,14 +398,14 @@ if exist "!WINGET_OUT!" (
 REM Write to log file if Log option enabled
 if exist "!WINGET_OUT!" (
     if !OPT_LOG!==1 (
-        echo === !pkg! [!STATUS!] ===>>"%~dp0!OPT_LOGFILE!"
-        type "!WINGET_OUT!">>"%~dp0!OPT_LOGFILE!"
-        echo.>>"%~dp0!OPT_LOGFILE!"
+        echo === !pkg! [!STATUS!] ===>>!PCGR_LOGDIR!!OPT_LOGFILE!
+        type "!WINGET_OUT!">>!PCGR_LOGDIR!!OPT_LOGFILE!
+        echo.>>!PCGR_LOGDIR!!OPT_LOGFILE!
     )
     if !OPT_LOG!==2 if "!STATUS!"=="FAILED" (
-        echo === FAILED: !pkg! ===>>"%~dp0!OPT_LOGFILE!"
-        type "!WINGET_OUT!">>"%~dp0!OPT_LOGFILE!"
-        echo.>>"%~dp0!OPT_LOGFILE!"
+        echo === FAILED: !pkg! ===>>!PCGR_LOGDIR!!OPT_LOGFILE!
+        type "!WINGET_OUT!">>!PCGR_LOGDIR!!OPT_LOGFILE!
+        echo.>>!PCGR_LOGDIR!!OPT_LOGFILE!
     )
 )
 
@@ -437,8 +463,8 @@ echo.
 REM FAIL_LOG is displayed at end screen, deleted there
 
 REM Show log file location if logging was enabled
-if !OPT_LOG! GEQ 1 if exist "%~dp0!OPT_LOGFILE!" (
-    call :rainbow "Log saved to: %~dp0!OPT_LOGFILE!"
+if !OPT_LOG! GEQ 1 if exist "!PCGR_LOGDIR!!OPT_LOGFILE!" (
+    call :rainbow "Log saved to: !PCGR_LOGDIR!!OPT_LOGFILE!"
     echo.
 )
 
@@ -473,7 +499,7 @@ if exist "%temp%\pcgr_failed_pkgs.txt" (
 )
 del "%temp%\pcgr_failed_pkgs.txt" 2>nul
 
-pause > nul
+if not defined PCGR_UNATTEND pause > nul
 color
 exit
 

--- a/Install.ps1
+++ b/Install.ps1
@@ -1,6 +1,16 @@
+# -Unattend: skip all interactive prompts and forward /Unattend to the elevated batch.
+# When the calling context is already elevated (e.g. autounattend.xml), the script
+# bypasses the extra UAC re-launch and runs AIOInstaller.bat directly.
+param([switch]$Unattend)
+
 # Log to file silently
 $LogFile = "$env:TEMP\PC-Gaming-Redists-Install.log"
 Start-Transcript -Path $LogFile -Force | Out-Null
+
+# Determine whether we are already running elevated (needed for autounattend path)
+$isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(
+    [Security.Principal.WindowsBuiltInRole]::Administrator
+)
 
 # PCGR ASCII Art Logo - rainbow gradient left to right
 $b = [char]0x2588  # full block
@@ -207,8 +217,14 @@ Function Install-AppxWithRetry
 						Write-Rainbow "  - $app"
 					}
 					Write-Host ""
-					$response = Read-Host "Close these apps to continue? (Y/n)"
-					if ($response -eq "" -or $response -match "^[Yy]") {
+					$doClose = $true
+					if (-not $script:Unattend) {
+						$response = Read-Host "Close these apps to continue? (Y/n)"
+						if ($response -notmatch "^[Yy]?" -or $response -match "^[Nn]") {
+							$doClose = $false
+						}
+					}
+					if ($doClose) {
 						Write-Rainbow "Closing blocking apps..."
 						Stop-BlockingPackages -PackageNames $blockingApps
 						# Also kill Edge as a precaution
@@ -399,8 +415,8 @@ try {
 	Write-Host "ERROR: Failed to download installer!" -ForegroundColor Red
 	Write-Host $_.Exception.Message -ForegroundColor Red
 	Stop-Transcript | Out-Null
-	pause
-	Return
+	if (-not $Unattend) { Read-Host "Press Enter to exit" | Out-Null }
+	exit 1
 }
 
 try {
@@ -419,13 +435,15 @@ try {
 if (!(Test-Path $FilePath)) {
 	Write-Host "ERROR: Download succeeded but file not found!" -ForegroundColor Red
 	Stop-Transcript | Out-Null
-	pause
-	Return
+	if (-not $Unattend) { Read-Host "Press Enter to exit" | Out-Null }
+	exit 1
 }
 
 # Rainbow text for launch message (bold)
 $bold = "$e[1m"
-if ($wingetFixRan) {
+if ($Unattend) {
+	$launchLines = @("          Launching AIOInstaller (unattended)...")
+} elseif ($wingetFixRan) {
 	$launchLines = @("Launching Installer Window.", "(Be sure to agree to UAC prompt)")
 } else {
 	$launchLines = @("          Launching Installer Window.", "        (Be sure to agree to UAC prompt)")
@@ -441,7 +459,7 @@ foreach ($line in $launchLines) {
     }
     Write-Host "$out$r"
 }
-Start-Sleep -Seconds 3
+if (-not $Unattend) { Start-Sleep -Seconds 3 }
 
 # Disable QuickEdit for this session only (doesn't modify registry, safe if script is cancelled)
 $QuickEditCode = @"
@@ -466,13 +484,25 @@ try {
 } catch { }
 
 try {
-	Start-Process -Verb runAs $FilePath -Wait
+	if ($Unattend -and $isAdmin) {
+		# Already elevated (e.g. called from autounattend.xml or an admin shell).
+		# Run the batch directly in this session - no UAC popup, no new privilege level needed.
+		Start-Process -FilePath $FilePath -ArgumentList '/Unattend' -Wait
+	} elseif ($Unattend) {
+		# Need elevation. Forward /Unattend so the elevated batch skips interactive prompts.
+		Start-Process -FilePath $FilePath -Verb RunAs -ArgumentList '/Unattend' -Wait
+	} else {
+		# Interactive mode - original behaviour.
+		Start-Process -Verb runAs $FilePath -Wait
+	}
 } catch {
 	Write-Host "ERROR launching installer: $_" -ForegroundColor Red
-	pause
+	if (-not $Unattend) { Read-Host "Press Enter to exit" | Out-Null }
+	exit 1
 }
 
 # Cleanup
 try { Remove-Item $FilePath -Force -ErrorAction SilentlyContinue } catch { }
 
+Write-Host "Install.ps1 complete. Log: $LogFile"
 Stop-Transcript | Out-Null

--- a/README.md
+++ b/README.md
@@ -29,5 +29,63 @@ Download and run [Install.bat](https://raw.githack.com/harryeffinpotter/PC-Gamin
 
 [![Github All Releases](https://img.shields.io/github/downloads/harryeffinpotter/PC-Gaming-Redists/total.svg)]()  ![](https://komarev.com/ghpvc/?username=harryeffinpotter) (since 04-12-2024)
 
+---
+
+## Unattended / Silent Installation
+
+Both `Install.ps1` and `AIOInstaller.bat` support a **`/Unattend`** (batch) / **`-Unattend`** (PowerShell) flag that:
+
+- Skips all interactive prompts (splash menu, WinGet retry questions, end-of-run pause)
+- Enables full logging to `%TEMP%\pcgr_aio_<COMPUTERNAME>.log`
+- Auto-retries a broken WinGet up to 5 times (10 s apart) before exiting with code 1
+- Returns a non-zero exit code on fatal errors so calling orchestrators can detect failure
+
+### Unattended one-liner (PowerShell 5.1+)
+
+```powershell
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+& ([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/harryeffinpotter/PC-Gaming-Redists/main/Install.ps1').Content)) -Unattend
+```
+
+> **Tip – fork pinning:** For reproducible deployments, replace `main` with a specific commit SHA
+> (e.g. `.../abc1234.../Install.ps1`) so your image is never broken by upstream changes.
+
+### `autounattend.xml` integration
+
+Add this to your `<FirstLogonCommands>` pass (runs as the first logged-on user, **after** a user
+account exists — required for WinGet / Microsoft Store packages to work correctly):
+
+```xml
+<FirstLogonCommands>
+  <SynchronousCommand wcm:action="add">
+    <Order>1</Order>
+    <RequiresUserInput>false</RequiresUserInput>
+    <CommandLine>powershell.exe -ExecutionPolicy Bypass -NoProfile -Command "&amp; { [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &amp; ([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/harryeffinpotter/PC-Gaming-Redists/main/Install.ps1').Content)) -Unattend }"</CommandLine>
+    <Description>Install PC Gaming Redistributables</Description>
+  </SynchronousCommand>
+</FirstLogonCommands>
+```
+
+#### Important notes for `autounattend.xml`
+
+| Topic | Recommendation |
+|---|---|
+| **Pass to use** | `FirstLogonCommands` (OOBE / first user logon). Do **not** use `specialize` — WinGet and AppX packages require a real user session and the Microsoft Store service to be running. |
+| **Already elevated?** | If your `autounattend.xml` sets the account as Administrator, `Install.ps1 -Unattend` detects that and skips the inner UAC re-launch (runs `AIOInstaller.bat /Unattend` directly). |
+| **Execution policy** | Always pass `-ExecutionPolicy Bypass` on the outer `powershell.exe` call; do not rely on the machine policy being set before OOBE. |
+| **Log location** | `%TEMP%\PC-Gaming-Redists-Install.log` (Install.ps1 transcript) + `%TEMP%\pcgr_aio_<HOSTNAME>.log` (per-package winget log from AIOInstaller.bat). |
+| **Exit codes** | Exit `0` = success; exit `1` = fatal error (WinGet unavailable, download failed, or launch failed). Packages that fail individually do **not** abort the run — they are logged and counted in the summary. |
+
+### Running directly from an elevated shell (no UAC popup)
+
+```powershell
+# From an elevated PowerShell prompt:
+powershell.exe -ExecutionPolicy Bypass -NoProfile -File AIOInstaller.bat /Unattend
+# or via Install.ps1 (auto-detects elevation, skips UAC re-launch):
+powershell.exe -ExecutionPolicy Bypass -NoProfile -Command "& { ... } -Unattend"
+```
+
+---
+
 ## Troubleshooting
 If you experience any problems please submit an issue so I can fix all angles of this thing, once and for all!


### PR DESCRIPTION
## What this adds

A /Unattend flag for fully automated, zero-interaction installs - useful for imaging workflows (utounattend.xml, MDT, etc.) or just not wanting to click anything.

## Changes

**AIOInstaller.bat**
- Parse /Unattend or -Unattend after UAC elevation (VBS stub already forwards extra args)
- Skip splash/menu and jump straight to install
- WinGet check: auto-retry up to 5x (10 s each) instead of interactive prompt
- Fatal errors exit with code 1 instead of pausing
- Log goes to %TEMP%\pcgr_aio_<COMPUTERNAME>.log when unattended

**Install.ps1**
- Add param([switch]$Unattend) - PS 5.1 compatible, no new dependencies
- Detects if already elevated - if so, runs the batch directly (no second UAC popup)
- If not elevated, passes /Unattend through Start-Process -Verb RunAs
- Replaces pause calls with conditional prompts + exit 1 on failures

**README.md**
- New *Unattended / Silent Installation* section with one-liner, utounattend.xml snippet, and notes on log paths, exit codes, and pinning to a commit SHA

## Usage

From any non-elevated shell:

`powershell
[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
& ([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/harryeffinpotter/PC-Gaming-Redists/main/Install.ps1').Content)) -Unattend
`

From an already-elevated shell (no UAC at all):

`powershell
powershell.exe -ExecutionPolicy Bypass -File Install.ps1 -Unattend
`

All existing interactive behaviour is unchanged - the flag is purely additive.
